### PR TITLE
Resumable upload

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.0
 
 import PackageDescription
 


### PR DESCRIPTION
My first attempt in trying to implement resumable uploads while referencing this: [https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload](url)

**Motivation**
I have my vapor server deployed on Google App Engine, however, when attempting to upload a file (around 43mb) into my Google Cloud Storage Bucket, the server returns a 413 error. Over the past few days I've been also trying to build the post request manually through Vapor's HTTPClient [https://docs.vapor.codes/3.0/vapor/client/](url) but I've had no luck correctly building and sending the request. There's not many examples or more details in the documentation as to how to achieve this. 
The only other way I've had actual success uploading a large file into my storage bucket is through gsutil, but for the purposes of my deployed project, it's not really practical to do that. 

As of right now, the method I implemented isn't working. Pretty sure I'm missing a lot here, but I'm happy to help out however I can.


