### PR TITLE
hot fix.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0-alpha")
     ],
     targets: [

--- a/Storage/Sources/StorageClient.swift
+++ b/Storage/Sources/StorageClient.swift
@@ -37,6 +37,7 @@ public final class GoogleCloudStorageClient {
         guard let projectId = ProcessInfo.processInfo.environment["PROJECT_ID"] ??
                                 (refreshableToken as? OAuthServiceAccount)?.credentials.projectId ??
                                 storageConfig.project ?? configuration.project else {
+            try? client.syncShutdown()
             throw GoogleCloudStorageError.projectIdMissing
         }
 


### PR DESCRIPTION
Use release tag for AsyncHttpClient and call syncShutdown when an error is thrown.