### PR TITLE
Move credential loading to configuration setup.

### DIFF
--- a/Core/Sources/Configuration/Credentials/GoogleCloudCredentials.swift
+++ b/Core/Sources/Configuration/Credentials/GoogleCloudCredentials.swift
@@ -72,28 +72,29 @@ public struct GoogleServiceAccountCredentials: Codable {
 }
 
 public class OAuthCredentialLoader {
-    public static func getRefreshableToken(credentialFilePath: String, withConfig config: GoogleCloudAPIConfiguration, andClient client: HTTPClient, eventLoop: EventLoop) throws -> OAuthRefreshable {
+    public static func getRefreshableToken(credentials: GoogleCloudCredentialsConfiguration,
+                                           withConfig config: GoogleCloudAPIConfiguration,
+                                           andClient client: HTTPClient,
+                                           eventLoop: EventLoop) -> OAuthRefreshable {
         
         // Check Service account first.
-        if let credentials = try? GoogleServiceAccountCredentials(fromFilePath: credentialFilePath) {
-            return OAuthServiceAccount(credentials: credentials, scopes: config.scope, httpClient: client, eventLoop: eventLoop)
+        if let serviceAccount = credentials.serviceAccountCredentials {
+            return OAuthServiceAccount(credentials: serviceAccount,
+                                       scopes: config.scope,
+                                       httpClient: client,
+                                       eventLoop: eventLoop)
         }
-
-        if let credentials = try? GoogleServiceAccountCredentials(fromJsonString: credentialFilePath) {
-            return OAuthServiceAccount(credentials: credentials, scopes: config.scope, httpClient: client, eventLoop: eventLoop)
-        }
-        
         
         // Check Default application credentials next.
-        if let credentials = try? GoogleApplicationDefaultCredentials(fromFilePath: credentialFilePath) {
-            return OAuthApplicationDefault(credentials: credentials, httpClient: client, eventLoop: eventLoop)
-        }
-
-        if let credentials = try? GoogleApplicationDefaultCredentials(fromJsonString: credentialFilePath) {
-            return OAuthApplicationDefault(credentials: credentials, httpClient: client, eventLoop: eventLoop)
+        if let appDefaultCredentials = credentials.applicationDefaultCredentials {
+            return OAuthApplicationDefault(credentials: appDefaultCredentials,
+                                           httpClient: client,
+                                           eventLoop: eventLoop)
         }
 
         // If neither work assume we're on GCP infrastructure.
-        return OAuthComputeEngineAppEngineFlex(serviceAccount: config.serviceAccount, httpClient: client, eventLoop: eventLoop)
+        return OAuthComputeEngineAppEngineFlex(serviceAccount: config.serviceAccount,
+                                               httpClient: client,
+                                               eventLoop: eventLoop)
     }
 }

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -12,13 +12,13 @@
 //import AsyncHTTPClient
 //import NIO
 //
-//let credentialsConfiguration = GoogleCloudCredentialsConfiguration()
-//
-//let cloudStorageConfiguration: GoogleCloudStorageConfiguration = .default()
 //let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 //let client = HTTPClient(eventLoopGroupProvider: .shared(elg),
 //                        configuration: .init(ignoreUncleanSSLShutdown: true))
 //do {
+//    let credentialsConfiguration = try GoogleCloudCredentialsConfiguration()
+//
+//    let cloudStorageConfiguration: GoogleCloudStorageConfiguration = .default()
 //    let gcs = try GoogleCloudStorageClient(credentials: credentialsConfiguration,
 //                                            storageConfig: cloudStorageConfiguration,
 //                                            httpClient: client,
@@ -32,3 +32,4 @@
 //} catch {
 //    print(error)
 //}
+//try? client.syncShutdown()

--- a/Storage/Sources/StorageClient.swift
+++ b/Storage/Sources/StorageClient.swift
@@ -24,12 +24,15 @@ public final class GoogleCloudStorageClient {
     /// - Parameter storageConfig: The storage configuration for the Cloud Storage API
     /// - Parameter httpClient: An `HTTPClient` used for making API requests.
     /// - Parameter eventLoop: The EventLoop used to perform the work on.
-    public init(credentials: GoogleCloudCredentialsConfiguration, storageConfig: GoogleCloudStorageConfiguration, httpClient: HTTPClient, eventLoop: EventLoop) throws {
+    public init(credentials: GoogleCloudCredentialsConfiguration,
+                storageConfig: GoogleCloudStorageConfiguration,
+                httpClient: HTTPClient,
+                eventLoop: EventLoop) throws {
         /// A token implementing `OAuthRefreshable`. Loaded from credentials specified by `GoogleCloudCredentialsConfiguration`.
-        let refreshableToken = try OAuthCredentialLoader.getRefreshableToken(credentialFilePath: credentials.serviceAccountCredentialsPath,
-                                                                             withConfig: storageConfig,
-                                                                             andClient: httpClient,
-                                                                             eventLoop: eventLoop)
+        let refreshableToken = OAuthCredentialLoader.getRefreshableToken(credentials: credentials,
+                                                                         withConfig: storageConfig,
+                                                                         andClient: httpClient,
+                                                                         eventLoop: eventLoop)
 
         /// Set the projectId to use for this client. In order of priority:
         /// - Environment Variable (PROJECT_ID)


### PR DESCRIPTION
This PR updates the `GoogleCloudCredentialsConfiguration` to read the service account from disk rather than having `GoogleCloudStorageClient` be initialized and have it try to read from disk.
This approach has the benefit of reducing overhead by not having to block and read from disk if a user initializes a `GoogleCloudStorageClient` in a computed property for example. Setting up the configuration to perform that work steers a user to do that operation once and in a manner where a system is still initializing and it's ok to take that overhead.