### PR TITLE
Clean up transaction handling

### DIFF
--- a/Datastore/Sources/Data API/API/ProjectAPI.swift
+++ b/Datastore/Sources/Data API/API/ProjectAPI.swift
@@ -20,10 +20,9 @@ public protocol DatastoreProjectAPI {
        
     /// Commits a transaction, optionally creating, deleting or modifying some entities.
     /// - Parameters:
-    ///   - mode: The type of commit to perform. Defaults to TRANSACTIONAL.
+    ///   - mode: The type of commit to perform.
     ///   - mutations: The mutations to perform.
-    ///   - transactionId: The identifier of the transaction associated with the commit. A transaction identifier is returned by a call to beginTransaction(transactionOptions:).
-    func commit(mode: CommitRequest.Mode, mutations: [CommitRequest.Mutation], transactionId: String) -> EventLoopFuture<CommitResponse>
+    func commit(mode: CommitRequest.Mode, mutations: [CommitRequest.Mutation]) -> EventLoopFuture<CommitResponse>
     
     /// Looks up entities by key.
     /// - Parameter keys: Keys of entities to look up.
@@ -55,8 +54,8 @@ extension DatastoreProjectAPI {
         return beginTransaction(transactionOptions: transactionOptions)
     }
     
-    public func commit(mode: CommitRequest.Mode = .transactional, mutations: [CommitRequest.Mutation], transactionId: String) -> EventLoopFuture<CommitResponse> {
-        return commit(mode: mode, mutations: mutations, transactionId: transactionId)
+    public func commit(mode: CommitRequest.Mode = .nonTransactional, mutations: [CommitRequest.Mutation]) -> EventLoopFuture<CommitResponse> {
+        return commit(mode: mode, mutations: mutations)
     }
     
     public func lookup(keys: [Key]) -> EventLoopFuture<LookupResponse> {
@@ -121,9 +120,9 @@ public final class GoogleCloudDatastoreProjectAPI: DatastoreProjectAPI {
         }
     }
     
-    public func commit(mode: CommitRequest.Mode = .transactional, mutations: [CommitRequest.Mutation], transactionId: String) -> EventLoopFuture<CommitResponse> {
+    public func commit(mode: CommitRequest.Mode = .nonTransactional, mutations: [CommitRequest.Mutation]) -> EventLoopFuture<CommitResponse> {
         do {
-            let commitRequest = CommitRequest(mode: mode, mutations: mutations, transaction: transactionId)
+            let commitRequest = CommitRequest(mode: mode, mutations: mutations)
             
             let body = try HTTPClient.Body.data(encoder.encode(commitRequest))
             return request.send(method: .POST, path: "\(projectPath):commit", body: body)

--- a/Datastore/Sources/Data API/Models/Project API/Request/CommitRequest.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Request/CommitRequest.swift
@@ -1,31 +1,57 @@
 import Core
 
 public struct CommitRequest: GoogleCloudModel {
-    public init(mode: Mode = .transactional, mutations: [Mutation], transaction: String) {
+    
+    public init(mode: Mode = .nonTransactional, mutations: [Mutation]) {
         self.mode = mode
         self.mutations = mutations
-        self.transaction = transaction
     }
     
-    /// The type of commit to perform. Defaults to TRANSACTIONAL.
+    /// The type of commit to perform.
     public let mode: Mode
     /// The mutations to perform.
     /// When mode is TRANSACTIONAL, mutations affecting a single entity are applied in order. The following sequences of mutations affecting a single entity are not permitted in a single projects.commit request:
     /// - insert followed by insert
     /// - update followed by insert
     /// - upsert followed by insert
-    /// - depublic lete followed by update
+    /// - delete followed by update
     /// When mode is NON_TRANSACTIONAL, no two mutations may affect a single entity.
     public let mutations: [Mutation]
     /// The identifier of the transaction associated with the commit.
-    public let transaction: String
-    
+    private var transaction: String?
+        
     /// The modes available for commits.
-    public enum Mode: String, RawRepresentable, GoogleCloudModel {
+    public enum Mode: GoogleCloudModel {
+        
         /// Transactional: The mutations are either all applied, or none are applied.
-        case transactional = "TRANSACTIONAL"
+        /// The associated value is a transaction ID obtained from a call to beginTransaction()
+        case transactional(String)
         /// Non-transactional: The mutations may not apply as all or none.
-        case nonTransactional = "NON_TRANSACTIONAL"
+        case nonTransactional
+        
+        enum CodingKeys: String, CodingKey {
+            case transactional
+            case nonTransactional
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let stringValue = try container.decodeIfPresent(String.self, forKey: .transactional) {
+                self = .transactional(stringValue)
+            } else {
+                self = .nonTransactional
+            }
+        }
+        
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .transactional(let value):
+                try container.encode(Mode.transactional(value), forKey: .transactional)
+            case .nonTransactional:
+                try container.encode(Mode.nonTransactional, forKey: .nonTransactional)
+            }
+        }
     }
     
     /// A mutation to apply to an entity.
@@ -65,13 +91,33 @@ public struct CommitRequest: GoogleCloudModel {
         }
         /// The version of the entity that this mutation is being applied to. If this does not match the current version on the server, the mutation conflicts.
         public let baseVersion: String?
-        /// The key of the entity to depublic lete. The entity may or may not already exist. Must have a comppublic lete key path and must not be reserved/read-only.
+        /// The key of the entity to delete. The entity may or may not already exist. Must have a complete key path and must not be reserved/read-only.
         public let delete: Key?
-        /// The entity to insert. The entity must not already exist. The entity key's final path element may be incomppublic lete.
+        /// The entity to insert. The entity must not already exist. The entity key's final path element may be incomplete.
         public let insert: Entity?
-        /// The entity to update. The entity must already exist. Must have a comppublic lete key path.
+        /// The entity to update. The entity must already exist. Must have a complete key path.
         public let update: Entity?
-        /// The entity to upsert. The entity may or may not already exist. The entity key's final path element may be incomppublic lete.
+        /// The entity to upsert. The entity may or may not already exist. The entity key's final path element may be incomplete.
         public let upsert: Entity?
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case mode
+        case mutations
+        case transaction
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(mutations, forKey: .mutations)
+        
+        switch mode {
+        case .transactional(let value):
+            try container.encode("TRANSACTIONAL", forKey: .mode)
+            try container.encode(value, forKey: .transaction)
+        case .nonTransactional:
+            try container.encode("NON_TRANSACTIONAL", forKey: .mode)
+            return
+        }
     }
 }

--- a/Datastore/Sources/README.md
+++ b/Datastore/Sources/README.md
@@ -57,7 +57,7 @@ func createEntity() {
    let entity = Entity(key: key, properties: properties)
    let insert = CommitRequest.Mutation(.insert(entity))
 
-    datastore.project.commit(mode: .transactional, mutations: [insert], transactionId: "myTransactionId").map { response in
+    datastore.project.commit(mutations: [insert]).map { response in
         print(response.indexUpdates) // prints 1
     }
 }


### PR DESCRIPTION
Safer (from a type point of view, as you can't now create a transactional commit without a transaction ID) and nicer to use at the call-site.