### PR TITLE
Media download bug

### DIFF
--- a/Storage/Sources/API/StorageObjectAPI.swift
+++ b/Storage/Sources/API/StorageObjectAPI.swift
@@ -314,7 +314,7 @@ extension StorageObjectAPI {
 public final class GoogleCloudStorageObjectAPI: StorageObjectAPI {
     let endpoint = "https://www.googleapis.com/storage/v1/b"
     let uploadEndpoint = "https://www.googleapis.com/upload/storage/v1/b"
-    let mediaDownloadEndpoint = "https://storage.googleapis.com/"
+    let mediaDownloadEndpoint = "https://storage.googleapis.com"
     let request: GoogleCloudStorageRequest
     
     init(request: GoogleCloudStorageRequest) {

--- a/Storage/Sources/API/StorageObjectAPI.swift
+++ b/Storage/Sources/API/StorageObjectAPI.swift
@@ -314,6 +314,7 @@ extension StorageObjectAPI {
 public final class GoogleCloudStorageObjectAPI: StorageObjectAPI {
     let endpoint = "https://www.googleapis.com/storage/v1/b"
     let uploadEndpoint = "https://www.googleapis.com/upload/storage/v1/b"
+    let mediaDownloadEndpoint = "https://storage.googleapis.com/"
     let request: GoogleCloudStorageRequest
     
     init(request: GoogleCloudStorageRequest) {
@@ -382,10 +383,7 @@ public final class GoogleCloudStorageObjectAPI: StorageObjectAPI {
     public func getMedia(bucket: String, object: String, range: ClosedRange<Int>?, queryParameters: [String: String]?) -> EventLoopFuture<GoogleCloudStorgeDataResponse> {
         var queryParams = ""
         if var queryParameters = queryParameters {
-            queryParameters["alt"] = "media"
             queryParams = queryParameters.queryParameters
-        } else {
-            queryParams = "alt=media"
         }
 
         var headers: HTTPHeaders = [:]
@@ -394,7 +392,7 @@ public final class GoogleCloudStorageObjectAPI: StorageObjectAPI {
             headers.add(name: "Range", value: "bytes=\(range.lowerBound)-\(range.upperBound)")
         }
         
-        return request.send(method: .GET, headers: headers, path: "\(endpoint)/\(bucket)/o/\(object)", query: queryParams)
+        return request.send(method: .GET, headers: headers, path: "\(mediaDownloadEndpoint)/\(bucket)/\(object)", query: queryParams)
     }
     
     public func createSimpleUpload(bucket: String,


### PR DESCRIPTION
Hi folks -- thanks for this library!

This is a PR that fixes what I'm pretty sure is a non-working endpoint for media downloads.

Google [appears to suggest](https://cloud.google.com/storage/docs/request-endpoints) that the URL scheme in `master` ought to work:

```
https://storage.googleapis.com/download/storage/v1/b/BUCKET_NAME/o/OBJECT_NAME?alt=media
```

But in my experience it just doesn't -- perhaps I'm doing something wrong.

Switching to this scheme for media downloads, however, seems to resolve the issue:

```
https://storage.googleapis.com/storage/v1/PATH_TO_RESOURCE
```

 