### PR TITLE
Updating storage endpoint to match with documentation

### DIFF
--- a/Storage/Sources/API/StorageObjectAPI.swift
+++ b/Storage/Sources/API/StorageObjectAPI.swift
@@ -312,8 +312,8 @@ extension StorageObjectAPI {
 }
 
 public final class GoogleCloudStorageObjectAPI: StorageObjectAPI {
-    let endpoint = "https://www.googleapis.com/storage/v1/b"
-    let uploadEndpoint = "https://www.googleapis.com/upload/storage/v1/b"
+    let endpoint = "https://storage.googleapis.com/storage/v1/b"
+    let uploadEndpoint = "https://storage.googleapis.com/upload/storage/v1/b"
     let request: GoogleCloudStorageRequest
     
     init(request: GoogleCloudStorageRequest) {


### PR DESCRIPTION
Documentation is suggesting this URL for media download, with `alt=media`:
```
GET https://storage.googleapis.com/storage/v1/b/bucket/o/object
```

See documentation here: https://cloud.google.com/storage/docs/json_api/v1/objects/get