### PR TITLE
Using class keyword is deprecated, replacing by AnyObject

### DIFF
--- a/Core/Sources/GoogleCloudAPIRequest.swift
+++ b/Core/Sources/GoogleCloudAPIRequest.swift
@@ -11,7 +11,7 @@ import NIOFoundationCompat
 import NIOHTTP1
 import AsyncHTTPClient
 
-public protocol GoogleCloudAPIRequest: class {
+public protocol GoogleCloudAPIRequest: AnyObject {
     var refreshableToken: OAuthRefreshable { get }
     var project: String { get }
     var httpClient: HTTPClient { get }


### PR DESCRIPTION
Had this warning when building. Just fixing it.

![Screenshot 2022-06-06 at 3 47 18 PM](https://user-images.githubusercontent.com/30439790/174473208-f343c50d-66de-4944-af10-6550be772992.png)
