### PR TITLE
Update Various Versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,13 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.7
 
 import PackageDescription
 
 let package = Package(
     name: "google-cloud-kit",
-    platforms: [ .macOS(.v10_15)],
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v13)
+    ],
     products: [
         .library(
             name: "GoogleCloudKit",
@@ -36,8 +39,8 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.2.0"),
-        .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0")
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.18.0"),
+        .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.13.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
- `swift-tools` ~~5.2~~ -> 5.7
- `macOS` ~~10.15~~ -> 13
- `iOS` -> minimum 13
- `async-http-client` ~~from 1.2.0~~ -> from 1.18.0
- `jwt-kit` ~~from 4.0.0~~ -> from 4.13.0

The two dependencies shouldn't have needed a bump but I've noticed that SPM tends to be inconsistent with its version resolution and will randomly change the minor/patch version on different invocations of `swift package update`. This just pins the minimums to the current stable releases according to the swift tools and macOS version updates.

This would constitute a major version bump of this package, but seeing as it's currently only `1.0.0-rc.*` it might be an opportunity to just release `1.0.0`