### PR TITLE
update to jwt-kit v5beta

### DIFF
--- a/Core/Sources/Configuration/OAuth/OAuthPayload.swift
+++ b/Core/Sources/Configuration/OAuth/OAuthPayload.swift
@@ -23,7 +23,7 @@ public struct OAuthPayload: JWTPayload {
     /// Using to nominate the account you want access to on the domain from a service account
     var sub: String?
     
-    public func verify(using signer: JWTSigner) throws {
+    public func verify(using algorithm: any JWTAlgorithm) async throws {
         try exp.verifyNotExpired()
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "google-cloud-kit",
     platforms: [
         .macOS(.v13),
-        .iOS(.v13)
+        .iOS(.v16)
     ],
     products: [
         .library(
@@ -51,7 +51,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.18.0"),
-        .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.13.0")
+        .package(url: "https://github.com/vapor/jwt-kit.git", from: "5.0.0-beta.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
This updates google-cloud-kit to use the new v5 version of jwt-kit. Currently a beta tag. 
The new release contains some API improvements and no longer vendors BoringSSL! 