### PR TITLE
Datastore aggregation query, composite filter and multiple database support

### DIFF
--- a/Datastore/Sources/Data API/API/ProjectAPI.swift
+++ b/Datastore/Sources/Data API/API/ProjectAPI.swift
@@ -5,8 +5,10 @@ import Foundation
 public protocol DatastoreProjectAPI {
     
     /// Allocates IDs for the given keys, which is useful for referencing an entity before it is inserted
-    /// - Parameter keys: A list of keys with incomplete key paths for which to allocate IDs. No key may be reserved/read-only.
-    func allocateIDs(keys: [Key]) -> EventLoopFuture<AllocateIdsResponse>
+    /// - Parameters:
+    ///   - keys: A list of keys with incomplete key paths for which to allocate IDs. No key may be reserved/read-only.
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func allocateIDs(keys: [Key], databaseId: String?) -> EventLoopFuture<AllocateIdsResponse>
     
     /// Prevents the supplied keys' IDs from being auto-allocated by Cloud Datastore.
     /// - Parameters:
@@ -15,29 +17,35 @@ public protocol DatastoreProjectAPI {
     func reserveIDs(databaseId: String?, keys: [Key]) -> EventLoopFuture<EmptyResponse>
     
     /// Begins a new transaction.
-    /// - Parameter transactionOptions: Options for a new transaction.
-    func beginTransaction(transactionOptions: TransactionOptions) -> EventLoopFuture<BeginTransactionResponse>
+    /// - Parameters:
+    ///   - transactionOptions: Options for a new transaction.
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func beginTransaction(transactionOptions: TransactionOptions, databaseId: String?) -> EventLoopFuture<BeginTransactionResponse>
        
     /// Commits a transaction, optionally creating, deleting or modifying some entities.
     /// - Parameters:
     ///   - mode: The type of commit to perform.
     ///   - mutations: The mutations to perform.
-    func commit(mode: CommitRequest.Mode, mutations: [CommitRequest.Mutation]) -> EventLoopFuture<CommitResponse>
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func commit(mode: CommitRequest.Mode, mutations: [CommitRequest.Mutation], databaseId: String?) -> EventLoopFuture<CommitResponse>
     
     /// Looks up entities by key.
     /// - Parameter keys: Keys of entities to look up.
-    func lookup(keys: [Key]) -> EventLoopFuture<LookupResponse>
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func lookup(keys: [Key], databaseId: String?) -> EventLoopFuture<LookupResponse>
     
     /// Rolls back a transaction.
     /// - Parameter transactionId: The transaction identifier, returned by a call to beginTransaction(transactionOptions:).
-    func rollback(transactionId: String) -> EventLoopFuture<EmptyResponse>
+    ///   - databaseId: The ID of the database against which to make the request.
+    func rollback(transactionId: String, databaseId: String?) -> EventLoopFuture<EmptyResponse>
     
     /// Queries for entities.
     /// - Parameters:
     ///   - partitionId: The (optional) namespace and partition against which to run the query
     ///   - readOptions: The options for this query.
     ///   - datastoreQuery: A query to run, either of normal or GQL type
-    func runQuery(partitionId: PartitionId, readOptions: ReadOptions?, datastoreQuery: DatastoreQuery) -> EventLoopFuture<RunQueryResponse>
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func runQuery(partitionId: PartitionId, readOptions: ReadOptions?, datastoreQuery: DatastoreQuery, databaseId: String?) -> EventLoopFuture<RunQueryResponse>
     
     /// Runs a query and performs an aggregation (sum, count or average) on the results
     /// - Parameters:
@@ -45,151 +53,142 @@ public protocol DatastoreProjectAPI {
     ///   - aggregations: The aggregations to perform on the results of the given query
     ///   - partitionId: The (optional) namespace and partition against which to run the query
     ///   - readOptions: The options for this query
-    func runAggregationQuery(
-        query: Query,
-        aggregations: [Aggregation],
-        partitionId: PartitionId,
-        readOptions: ReadOptions?
-    ) -> EventLoopFuture<RunAggregationQueryResponse>
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func runAggregationQuery(query: Query, aggregations: [Aggregation], partitionId: PartitionId, readOptions: ReadOptions?, databaseId: String?) -> EventLoopFuture<RunAggregationQueryResponse>
     
     /// Runs an aggregation query in GQL format
     /// - Parameters:
     ///   - gqlQuery: The aggregation query to run in GQL format
     ///   - partitionId: The namespace and partition against which to run the query
     ///   - readOptions: The options for this query
-    func runAggregationQuery(
-        gqlQuery: GqlQuery,
-        partitionId: PartitionId,
-        readOptions: ReadOptions?
-    ) -> EventLoopFuture<RunAggregationQueryResponse>
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func runAggregationQuery(gqlQuery: GqlQuery, partitionId: PartitionId, readOptions: ReadOptions?, databaseId: String?) -> EventLoopFuture<RunAggregationQueryResponse>
     
     /// Inserts an entity
     /// Convenience method equivalent to calling `commit(mode:mutations:)` with a single insert mutation
-    /// - Parameter entity: The entity to insert
-    func insert(_ entity: Entity) -> EventLoopFuture<CommitResponse>
+    /// - Parameters:
+    ///   - entity: The entity to insert
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func insert(_ entity: Entity, databaseId: String?) -> EventLoopFuture<CommitResponse>
     
     /// Inserts multiple entities
     /// Convenience method equivalent to calling `commit(mode:mutations:)` with multiple insert mutations
-    /// - Parameter entity: The entities to insert
-    func insert(_ entities: [Entity]) -> EventLoopFuture<CommitResponse>
+    /// - Parameters:
+    ///   - entity: The entities to insert
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func insert(_ entities: [Entity], databaseId: String?) -> EventLoopFuture<CommitResponse>
     
     /// Updates an entity
     /// Convenience method equivalent to calling `commit(mode:mutations:)` with a single update mutation
-    /// - Parameter entity: The entities to update
-    func update(_ entity: Entity) -> EventLoopFuture<CommitResponse>
+    /// - Parameters:
+    ///   - entity: The entities to update
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func update(_ entity: Entity, databaseId: String?) -> EventLoopFuture<CommitResponse>
     
     /// Updates multiple entities
     /// Convenience method equivalent to calling `commit(mode:mutations:)` with multiple update mutations
-    /// - Parameter entity: The entities to update
-    func update(_ entities: [Entity]) -> EventLoopFuture<CommitResponse>
+    /// - Parameters:
+    ///   - entity: The entities to update
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func update(_ entities: [Entity], databaseId: String?) -> EventLoopFuture<CommitResponse>
     
     /// Upserts (update-or-insert) an entity
     /// Convenience method equivalent to calling `commit(mode:mutations:)` with a single upsert mutation
-    /// - Parameter entity: The entity to upsert
-    func upsert(_ entity: Entity) -> EventLoopFuture<CommitResponse>
+    /// - Parameters:
+    ///   - entity: The entity to upsert
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func upsert(_ entity: Entity, databaseId: String?) -> EventLoopFuture<CommitResponse>
     
     /// Upserts multiple entities
     /// Convenience method equivalent to calling `commit(mode:mutations:)` with multiple upsert mutations
-    /// - Parameter entity: The entities to upsert
-    func upsert(_ entities: [Entity]) -> EventLoopFuture<CommitResponse>
+    /// - Parameters:
+    ///   - entity: The entities to upsert
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func upsert(_ entities: [Entity], databaseId: String?) -> EventLoopFuture<CommitResponse>
     
     /// Deletes an entity
     /// Convenience method equivalent to calling `commit(mode:mutations:)` with a single delete mutation
-    /// - Parameter key: The key of the entity to delete
-    func delete(_ key: Key) -> EventLoopFuture<CommitResponse>
+    /// - Parameters:
+    ///   - key: The key of the entity to delete
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+   func delete(_ key: Key, databaseId: String?) -> EventLoopFuture<CommitResponse>
     
-    /// Deletes mutiple entities
+    /// Deletes multiple entities
     /// Convenience method equivalent to calling `commit(mode:mutations:)` with multiple delete mutations
-    /// - Parameter key: The keys of the entities to delete
-    func delete(_ keys: [Key]) -> EventLoopFuture<CommitResponse>
+    /// - Parameters:
+    ///   - key: The keys of the entities to delete
+    ///   - databaseId: The ID of the database against which to make the request. `nil` or an empty string refers to the default database.
+    func delete(_ keys: [Key], databaseId: String?) -> EventLoopFuture<CommitResponse>
 }
 
 extension DatastoreProjectAPI {
     
-    public func allocateIDs(keys: [Key]) -> EventLoopFuture<AllocateIdsResponse> {
-        return allocateIDs(keys: keys)
+    public func allocateIDs(keys: [Key], databaseId: String? = nil) -> EventLoopFuture<AllocateIdsResponse> {
+        return allocateIDs(keys: keys, databaseId: databaseId)
     }
     
-    func reserveIDs(databaseId: String? = nil, keys: [Key]) -> EventLoopFuture<EmptyResponse> {
+    public func reserveIDs(databaseId: String? = nil, keys: [Key]) -> EventLoopFuture<EmptyResponse> {
         return reserveIDs(databaseId: databaseId, keys: keys)
     }
     
-    public func beginTransaction(transactionOptions: TransactionOptions = .init()) -> EventLoopFuture<BeginTransactionResponse> {
-        return beginTransaction(transactionOptions: transactionOptions)
+    public func beginTransaction(transactionOptions: TransactionOptions = .init(), databaseId: String? = nil) -> EventLoopFuture<BeginTransactionResponse> {
+        return beginTransaction(transactionOptions: transactionOptions, databaseId: databaseId)
     }
     
-    public func commit(mode: CommitRequest.Mode = .nonTransactional, mutations: [CommitRequest.Mutation]) -> EventLoopFuture<CommitResponse> {
-        return commit(mode: mode, mutations: mutations)
+    public func commit(mode: CommitRequest.Mode = .nonTransactional, mutations: [CommitRequest.Mutation], databaseId: String? = nil) -> EventLoopFuture<CommitResponse> {
+        return commit(mode: mode, mutations: mutations, databaseId: databaseId)
     }
     
-    public func lookup(keys: [Key]) -> EventLoopFuture<LookupResponse> {
-        return lookup(keys: keys)
+    public func lookup(keys: [Key], databaseId: String? = nil) -> EventLoopFuture<LookupResponse> {
+        return lookup(keys: keys, databaseId: databaseId)
     }
     
-    public func rollback(transactionId: String) -> EventLoopFuture<EmptyResponse> {
-        return rollback(transactionId: transactionId)
+    public func rollback(transactionId: String, databaseId: String? = nil) -> EventLoopFuture<EmptyResponse> {
+        return rollback(transactionId: transactionId, databaseId: databaseId)
     }
    
-    public func runQuery(partitionId: PartitionId, readOptions: ReadOptions? = nil, datastoreQuery: DatastoreQuery) -> EventLoopFuture<RunQueryResponse> {
-        return runQuery(partitionId: partitionId, readOptions: readOptions, datastoreQuery: datastoreQuery)
+    public func runQuery(partitionId: PartitionId, readOptions: ReadOptions? = nil, datastoreQuery: DatastoreQuery, databaseId: String? = nil) -> EventLoopFuture<RunQueryResponse> {
+        return runQuery(partitionId: partitionId, readOptions: readOptions, datastoreQuery: datastoreQuery, databaseId: databaseId)
     }
     
-    public func runAggregationQuery(
-        query: Query,
-        aggregations: [Aggregation],
-        partitionId: PartitionId,
-        readOptions: ReadOptions? = nil
-    ) -> EventLoopFuture<RunAggregationQueryResponse> {
-        return runAggregationQuery(
-            query: query,
-            aggregations: aggregations,
-            partitionId: partitionId,
-            readOptions: readOptions
-        )
+    public func runAggregationQuery(query: Query, aggregations: [Aggregation], partitionId: PartitionId, readOptions: ReadOptions? = nil, databaseId: String? = nil) -> EventLoopFuture<RunAggregationQueryResponse> {
+        return runAggregationQuery(query: query, aggregations: aggregations, partitionId: partitionId, readOptions: readOptions, databaseId: databaseId)
     }
     
-    public func runAggregationQuery(
-        gqlQuery: GqlQuery,
-        partitionId: PartitionId,
-        readOptions: ReadOptions? = nil
-    ) -> EventLoopFuture<RunAggregationQueryResponse> {
-        return runAggregationQuery(
-            gqlQuery: gqlQuery,
-            partitionId: partitionId,
-            readOptions: readOptions
-        )
+    public func runAggregationQuery(gqlQuery: GqlQuery, partitionId: PartitionId, readOptions: ReadOptions? = nil, databaseId: String? = nil) -> EventLoopFuture<RunAggregationQueryResponse> {
+        return runAggregationQuery(gqlQuery: gqlQuery, partitionId: partitionId, readOptions: readOptions, databaseId: databaseId)
     }
     
-    public func insert(_ entity: Entity) -> EventLoopFuture<CommitResponse> {
-        return insert([entity])
+    public func insert(_ entity: Entity, databaseId: String? = nil) -> EventLoopFuture<CommitResponse> {
+        return insert([entity], databaseId: databaseId)
     }
     
-    public func insert(_ entities: [Entity]) -> EventLoopFuture<CommitResponse> {
-        return insert(entities)
+    public func insert(_ entities: [Entity], databaseId: String? = nil) -> EventLoopFuture<CommitResponse> {
+        return insert(entities, databaseId: databaseId)
     }
     
-    public func update(_ entity: Entity) -> EventLoopFuture<CommitResponse> {
-        return update(entity)
+    public func update(_ entity: Entity, databaseId: String? = nil) -> EventLoopFuture<CommitResponse> {
+        return update(entity, databaseId: databaseId)
     }
     
-    public func update(_ entities: [Entity]) -> EventLoopFuture<CommitResponse> {
-        return update(entities)
+    public func update(_ entities: [Entity], databaseId: String? = nil) -> EventLoopFuture<CommitResponse> {
+        return update(entities, databaseId: databaseId)
     }
     
-    public func upsert(_ entity: Entity) -> EventLoopFuture<CommitResponse> {
-        return upsert(entity)
+    public func upsert(_ entity: Entity, databaseId: String? = nil) -> EventLoopFuture<CommitResponse> {
+        return upsert(entity, databaseId: databaseId)
     }
     
-    public func upsert(_ entities: [Entity]) -> EventLoopFuture<CommitResponse> {
-        return upsert(entities)
+    public func upsert(_ entities: [Entity], databaseId: String? = nil) -> EventLoopFuture<CommitResponse> {
+        return upsert(entities, databaseId: databaseId)
     }
     
-    public func delete(_ key: Key) -> EventLoopFuture<CommitResponse> {
-        return delete(key)
+    public func delete(_ key: Key, databaseId: String? = nil) -> EventLoopFuture<CommitResponse> {
+        return delete(key, databaseId: databaseId)
     }
     
-    public func delete(_ keys: [Key]) -> EventLoopFuture<CommitResponse> {
-        return delete(keys)
+    public func delete(_ keys: [Key], databaseId: String? = nil) -> EventLoopFuture<CommitResponse> {
+        return delete(keys, databaseId: databaseId)
     }
 }
 
@@ -199,8 +198,10 @@ public final class GoogleCloudDatastoreProjectAPI: DatastoreProjectAPI {
     let request: GoogleCloudDatastoreRequest
     let encoder = JSONEncoder()
     
-    init(request: GoogleCloudDatastoreRequest,
-         endpoint: String) {
+    init(
+        request: GoogleCloudDatastoreRequest,
+        endpoint: String
+    ) {
         self.request = request
         self.endpoint = endpoint
     }
@@ -209,10 +210,16 @@ public final class GoogleCloudDatastoreProjectAPI: DatastoreProjectAPI {
         "\(endpoint)/v1/projects/\(request.project)"
     }
     
-    public func allocateIDs(keys: [Key]) -> EventLoopFuture<AllocateIdsResponse> {
+    public func allocateIDs(
+        keys: [Key],
+        databaseId: String? = nil
+    ) -> EventLoopFuture<AllocateIdsResponse> {
         
         do {
-            let allocateIdsRequest = AllocateIdsRequest(keys: keys)
+            let allocateIdsRequest = AllocateIdsRequest(
+                keys: keys,
+                databaseId: databaseId
+            )
             let body = try HTTPClient.Body.data(encoder.encode(allocateIdsRequest))
             return request.send(method: .POST, path: "\(projectPath):allocateIds", body: body)
         } catch {
@@ -220,11 +227,16 @@ public final class GoogleCloudDatastoreProjectAPI: DatastoreProjectAPI {
         }
     }
     
-    public func reserveIDs(databaseId: String? = nil, keys: [Key]) -> EventLoopFuture<EmptyResponse> {
+    public func reserveIDs(
+        databaseId: String? = nil,
+        keys: [Key]
+    ) -> EventLoopFuture<EmptyResponse> {
         
         do {
-            let reserveIdsRequest = ReserveIdsRequest(databaseId: databaseId, keys: keys)
-            
+            let reserveIdsRequest = ReserveIdsRequest(
+                databaseId: databaseId,
+                keys: keys
+            )
             let body = try HTTPClient.Body.data(encoder.encode(reserveIdsRequest))
             return request.send(method: .POST, path: "\(projectPath):reserveIds", body: body)
         } catch {
@@ -232,20 +244,35 @@ public final class GoogleCloudDatastoreProjectAPI: DatastoreProjectAPI {
         }
     }
     
-    public func beginTransaction(transactionOptions: TransactionOptions = .init()) -> EventLoopFuture<BeginTransactionResponse> {
+    public func beginTransaction(
+        transactionOptions: TransactionOptions = .init(),
+        databaseId: String? = nil
+    ) -> EventLoopFuture<BeginTransactionResponse> {
 
         do {
-            let body = try HTTPClient.Body.data(encoder.encode(transactionOptions))
+            let transactionRequest = BeginTransactionRequest(
+                transactionOptions: transactionOptions,
+                databaseId: databaseId
+            )
+            let body = try HTTPClient.Body.data(encoder.encode(transactionRequest))
             return request.send(method: .POST, path: "\(projectPath):beginTransaction", body: body)
         } catch {
             return request.eventLoop.makeFailedFuture(error)
         }
     }
     
-    public func commit(mode: CommitRequest.Mode = .nonTransactional, mutations: [CommitRequest.Mutation]) -> EventLoopFuture<CommitResponse> {
+    public func commit(
+        mode: CommitRequest.Mode = .nonTransactional,
+        mutations: [CommitRequest.Mutation],
+        databaseId: String? = nil
+    ) -> EventLoopFuture<CommitResponse> {
+        
         do {
-            let commitRequest = CommitRequest(mode: mode, mutations: mutations)
-            
+            let commitRequest = CommitRequest(
+                mode: mode,
+                mutations: mutations,
+                databaseId: databaseId
+            )
             let body = try HTTPClient.Body.data(encoder.encode(commitRequest))
             return request.send(method: .POST, path: "\(projectPath):commit", body: body)
         } catch {
@@ -253,11 +280,16 @@ public final class GoogleCloudDatastoreProjectAPI: DatastoreProjectAPI {
         }
     }
 
-    
-    public func lookup(keys: [Key]) -> EventLoopFuture<LookupResponse> {
+    public func lookup(
+        keys: [Key],
+        databaseId: String? = nil
+    ) -> EventLoopFuture<LookupResponse> {
 
         do {
-            let lookupRequest = LookupRequest(keys: keys)
+            let lookupRequest = LookupRequest(
+                keys: keys,
+                databaseId: databaseId
+            )
             let body = try HTTPClient.Body.data(encoder.encode(lookupRequest))
             return request.send(method: .POST, path: "\(projectPath):lookup", body: body)
         } catch {
@@ -265,10 +297,16 @@ public final class GoogleCloudDatastoreProjectAPI: DatastoreProjectAPI {
         }
     }
     
-    public func rollback(transactionId: String) -> EventLoopFuture<EmptyResponse> {
+    public func rollback(
+        transactionId: String,
+        databaseId: String? = nil
+    ) -> EventLoopFuture<EmptyResponse> {
         
         do {
-            let rollbackRequest = RollbackRequest(transaction: transactionId)
+            let rollbackRequest = RollbackRequest(
+                transaction: transactionId,
+                databaseId: databaseId
+            )
             let body = try HTTPClient.Body.data(encoder.encode(rollbackRequest))
             return request.send(method: .POST, path: "\(projectPath):rollback", body: body)
         } catch {
@@ -276,16 +314,33 @@ public final class GoogleCloudDatastoreProjectAPI: DatastoreProjectAPI {
         }
     }
     
-    public func runQuery(partitionId: PartitionId, readOptions: ReadOptions? = nil, datastoreQuery: DatastoreQuery) -> EventLoopFuture<RunQueryResponse> {
+    public func runQuery(
+        partitionId: PartitionId,
+        readOptions: ReadOptions? = nil,
+        datastoreQuery: DatastoreQuery,
+        databaseId: String? = nil
+    ) -> EventLoopFuture<RunQueryResponse> {
         
         do {
-            var runQueryRequest = RunQueryRequest()
+            let runQueryRequest: RunQueryRequest
             
             switch datastoreQuery {
             case .query(let query):
-                runQueryRequest = RunQueryRequest(gqlQuery: nil, partitionId: partitionId, query: query, readOptions: readOptions)
+                runQueryRequest = RunQueryRequest(
+                    gqlQuery: nil,
+                    partitionId: partitionId,
+                    query: query,
+                    readOptions: readOptions,
+                    databaseId: databaseId
+                )
             case .gqlQuery(let query):
-                runQueryRequest = RunQueryRequest(gqlQuery: query, partitionId: partitionId, query: nil, readOptions: readOptions)
+                runQueryRequest = RunQueryRequest(
+                    gqlQuery: query,
+                    partitionId: partitionId,
+                    query: nil,
+                    readOptions: readOptions,
+                    databaseId: databaseId
+                )
             }
             
             let body = try HTTPClient.Body.data(encoder.encode(runQueryRequest))
@@ -299,14 +354,16 @@ public final class GoogleCloudDatastoreProjectAPI: DatastoreProjectAPI {
         query: Query,
         aggregations: [Aggregation],
         partitionId: PartitionId,
-        readOptions: ReadOptions? = nil
+        readOptions: ReadOptions? = nil,
+        databaseId: String? = nil
     ) -> EventLoopFuture<RunAggregationQueryResponse> {
         
         let queryRequest = RunAggregationQueryRequest(
             query: query,
             aggregations: aggregations,
             partitionId: partitionId,
-            readOptions: readOptions
+            readOptions: readOptions,
+            databaseId: databaseId
         )
         
         do {
@@ -324,13 +381,15 @@ public final class GoogleCloudDatastoreProjectAPI: DatastoreProjectAPI {
     public func runAggregationQuery(
         gqlQuery: GqlQuery,
         partitionId: PartitionId,
-        readOptions: ReadOptions? = nil
+        readOptions: ReadOptions? = nil,
+        databaseId: String = ""
     ) -> EventLoopFuture<RunAggregationQueryResponse> {
         
         let queryRequest = RunAggregationQueryRequest(
             gqlQuery: gqlQuery,
             partitionId: partitionId,
-            readOptions: readOptions
+            readOptions: readOptions,
+            databaseId: databaseId
         )
         
         do {
@@ -345,39 +404,87 @@ public final class GoogleCloudDatastoreProjectAPI: DatastoreProjectAPI {
         }
     }
     
-    public func insert(_ entity: Entity) -> EventLoopFuture<CommitResponse> {
-        return insert([entity])
+    public func insert(
+        _ entity: Entity,
+        databaseId: String? = nil
+    ) -> EventLoopFuture<CommitResponse> {
+        return insert(
+            [entity],
+            databaseId: databaseId
+        )
     }
     
-    public func insert(_ entities: [Entity]) -> EventLoopFuture<CommitResponse> {
+    public func insert(
+        _ entities: [Entity],
+        databaseId: String? = nil
+    ) -> EventLoopFuture<CommitResponse> {
         let mutations = entities.map { CommitRequest.Mutation(.insert($0)) }
-        return commit(mutations: mutations)
+        return commit(
+            mutations: mutations,
+            databaseId: databaseId
+        )
     }
     
-    public func update(_ entity: Entity) -> EventLoopFuture<CommitResponse> {
-        return update([entity])
+    public func update(
+        _ entity: Entity,
+        databaseId: String? = nil
+    ) -> EventLoopFuture<CommitResponse> {
+        return update(
+            [entity],
+            databaseId: databaseId
+        )
     }
     
-    public func update(_ entities: [Entity]) -> EventLoopFuture<CommitResponse> {
+    public func update(
+        _ entities: [Entity],
+        databaseId: String? = nil
+    ) -> EventLoopFuture<CommitResponse> {
         let mutations = entities.map { CommitRequest.Mutation(.update($0)) }
-        return commit(mutations: mutations)
+        return commit(
+            mutations: mutations,
+            databaseId: databaseId
+        )
     }
     
-    public func upsert(_ entity: Entity) -> EventLoopFuture<CommitResponse> {
-        return upsert([entity])
+    public func upsert(
+        _ entity: Entity,
+        databaseId: String? = nil
+    ) -> EventLoopFuture<CommitResponse> {
+        return upsert(
+            [entity],
+            databaseId: databaseId
+        )
     }
     
-    public func upsert(_ entities: [Entity]) -> EventLoopFuture<CommitResponse> {
+    public func upsert(
+        _ entities: [Entity],
+        databaseId: String? = nil
+    ) -> EventLoopFuture<CommitResponse> {
         let mutations = entities.map { CommitRequest.Mutation(.upsert($0)) }
-        return commit(mutations: mutations)
+        return commit(
+            mutations: mutations,
+            databaseId: databaseId
+        )
     }
     
-    public func delete(_ key: Key) -> EventLoopFuture<CommitResponse> {
-        return delete([key])
+    public func delete(
+        _ key: Key,
+        databaseId: String? = nil
+    ) -> EventLoopFuture<CommitResponse> {
+        return delete(
+            [key],
+            databaseId: databaseId
+        )
     }
     
-    public func delete(_ keys: [Key]) -> EventLoopFuture<CommitResponse> {
+    public func delete(
+        _ keys: [Key],
+        databaseId: String? = nil
+    ) -> EventLoopFuture<CommitResponse> {
         let mutations = keys.map { CommitRequest.Mutation(.delete($0)) }
-        return commit(mutations: mutations)
+        return commit(
+            mutations: mutations,
+            databaseId: databaseId
+        )
     }
 }

--- a/Datastore/Sources/Data API/Models/Project API/Request/AllocateIdsRequest.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Request/AllocateIdsRequest.swift
@@ -1,9 +1,16 @@
 import Core
 
 public struct AllocateIdsRequest: GoogleCloudModel {
-    public init(keys: [Key]? = nil) {
+    public init(
+        keys: [Key]? = nil,
+        databaseId: String? = nil
+    ) {
+        self.databaseId = databaseId
         self.keys = keys
     }
-    /// A list of keys with incomppublic lete key paths for which to allocate IDs. No key may be reserved/read-only.
+    /// The ID of the database against which to make the request.
+    /// '(default)' is not allowed; please use empty string '' to refer the default database.
+    public let databaseId: String?
+    /// A list of keys with incomplete key paths for which to allocate IDs. No key may be reserved/read-only.
     public let keys: [Key]?
 }

--- a/Datastore/Sources/Data API/Models/Project API/Request/BeginTransactionRequest.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Request/BeginTransactionRequest.swift
@@ -1,9 +1,16 @@
 import Core
 
 public struct BeginTransactionRequest: GoogleCloudModel {
-    public init(transactionOptions: TransactionOptions? = nil) {
+    public init(
+        transactionOptions: TransactionOptions? = nil,
+        databaseId: String? = nil
+    ) {
         self.transactionOptions = transactionOptions
+        self.databaseId = databaseId
     }
     /// Options for a new transaction.
     public let transactionOptions: TransactionOptions?
+    /// The ID of the database against which to make the request.
+    /// '(default)' is not allowed; please use empty string '' to refer the default database.
+    public let databaseId: String?
 }

--- a/Datastore/Sources/Data API/Models/Project API/Request/CommitRequest.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Request/CommitRequest.swift
@@ -2,9 +2,14 @@ import Core
 
 public struct CommitRequest: GoogleCloudModel {
     
-    public init(mode: Mode = .nonTransactional, mutations: [Mutation]) {
+    public init(
+        mode: Mode = .nonTransactional,
+        mutations: [Mutation],
+        databaseId: String? = nil
+    ) {
         self.mode = mode
         self.mutations = mutations
+        self.databaseId = databaseId
     }
     
     /// The type of commit to perform.
@@ -19,6 +24,9 @@ public struct CommitRequest: GoogleCloudModel {
     public let mutations: [Mutation]
     /// The identifier of the transaction associated with the commit.
     private var transaction: String?
+    /// The ID of the database against which to make the request.
+    /// '(default)' is not allowed; please use empty string '' to refer the default database.
+    public let databaseId: String?
         
     /// The modes available for commits.
     public enum Mode: GoogleCloudModel {
@@ -105,11 +113,14 @@ public struct CommitRequest: GoogleCloudModel {
         case mode
         case mutations
         case transaction
+        case databaseId
     }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(mutations, forKey: .mutations)
+        try container.encodeIfPresent(databaseId, forKey: .databaseId)
+        try container.encodeIfPresent(transaction, forKey: .transaction)
         
         switch mode {
         case .transactional(let value):

--- a/Datastore/Sources/Data API/Models/Project API/Request/LookupRequest.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Request/LookupRequest.swift
@@ -1,14 +1,21 @@
 import Core
 
 public struct LookupRequest: GoogleCloudModel {
-    public init(keys: [Key]? = nil,
-                 readOptions: ReadOptions? = nil) {
+    public init(
+        keys: [Key]? = nil,
+        readOptions: ReadOptions? = nil,
+        databaseId: String? = nil
+    ) {
         self.keys = keys
         self.readOptions = readOptions
+        self.databaseId = databaseId
     }
     /// Keys of entities to look up.
     public let keys: [Key]?
     /// The options for this lookup request.
     public let readOptions: ReadOptions?
+    /// The ID of the database against which to make the request.
+    /// '(default)' is not allowed; please use empty string '' to refer the default database.
+    public let databaseId: String?
 }
 

--- a/Datastore/Sources/Data API/Models/Project API/Request/ReserveIdsRequest.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Request/ReserveIdsRequest.swift
@@ -1,8 +1,10 @@
 import Core
 
 public struct ReserveIdsRequest: GoogleCloudModel {
-    public init(databaseId: String? = nil,
-                 keys: [Key]) {
+    public init(
+        databaseId: String? = nil,
+        keys: [Key]
+    ) {
         self.databaseId = databaseId
         self.keys = keys
     }

--- a/Datastore/Sources/Data API/Models/Project API/Request/RollbackRequest.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Request/RollbackRequest.swift
@@ -1,6 +1,18 @@
 import Core
 
 public struct RollbackRequest: GoogleCloudModel {
+    
+    public init(
+        transaction: String,
+        databaseId: String? = nil
+    ) {
+        self.transaction = transaction
+        self.databaseId = databaseId
+    }
+    
     /// The transaction identifier,
     public let transaction: String
+    /// The ID of the database against which to make the request.
+    /// '(default)' is not allowed; please use empty string '' to refer the default database.
+    public let databaseId: String?
 }

--- a/Datastore/Sources/Data API/Models/Project API/Request/RunAggregationQueryRequest.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Request/RunAggregationQueryRequest.swift
@@ -5,24 +5,28 @@ struct RunAggregationQueryRequest: GoogleCloudModel {
     init(
         gqlQuery: GqlQuery,
         partitionId: PartitionId? = nil,
-        readOptions: ReadOptions? = nil
+        readOptions: ReadOptions? = nil,
+        databaseId: String? = nil
     ) {
         self.gqlQuery = gqlQuery
         self.aggregationQuery = nil
         self.partitionId = partitionId
         self.readOptions = readOptions
+        self.databaseId = databaseId
     }
     
     init(
         query: Query,
         aggregations: [Aggregation],
         partitionId: PartitionId? = nil,
-        readOptions: ReadOptions? = nil
+        readOptions: ReadOptions? = nil,
+        databaseId: String? = nil
     ) {
         self.aggregationQuery = AggregationQuery(aggregations: aggregations, nestedQuery: query)
         self.gqlQuery = nil
         self.partitionId = partitionId
         self.readOptions = readOptions
+        self.databaseId = databaseId
     }
     
     /// The GQL query to run.
@@ -33,5 +37,8 @@ struct RunAggregationQueryRequest: GoogleCloudModel {
     let partitionId: PartitionId?
     /// The options for this query.
     let readOptions: ReadOptions?
+    /// The ID of the database against which to make the request.
+    /// '(default)' is not allowed; please use empty string '' to refer the default database.
+    let databaseId: String?
 }
 

--- a/Datastore/Sources/Data API/Models/Project API/Request/RunAggregationQueryRequest.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Request/RunAggregationQueryRequest.swift
@@ -1,0 +1,37 @@
+import Core
+
+struct RunAggregationQueryRequest: GoogleCloudModel {
+    
+    init(
+        gqlQuery: GqlQuery,
+        partitionId: PartitionId? = nil,
+        readOptions: ReadOptions? = nil
+    ) {
+        self.gqlQuery = gqlQuery
+        self.aggregationQuery = nil
+        self.partitionId = partitionId
+        self.readOptions = readOptions
+    }
+    
+    init(
+        query: Query,
+        aggregations: [Aggregation],
+        partitionId: PartitionId? = nil,
+        readOptions: ReadOptions? = nil
+    ) {
+        self.aggregationQuery = AggregationQuery(aggregations: aggregations, nestedQuery: query)
+        self.gqlQuery = nil
+        self.partitionId = partitionId
+        self.readOptions = readOptions
+    }
+    
+    /// The GQL query to run.
+    let gqlQuery: GqlQuery?
+    /// The aggregation query to run.
+    let aggregationQuery: AggregationQuery?
+    /// The (optional) namespace and partition against which to run the query
+    let partitionId: PartitionId?
+    /// The options for this query.
+    let readOptions: ReadOptions?
+}
+

--- a/Datastore/Sources/Data API/Models/Project API/Request/RunQueryRequest.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Request/RunQueryRequest.swift
@@ -1,15 +1,19 @@
 import Core
 
 public struct RunQueryRequest: GoogleCloudModel {
-    public init(gqlQuery: GqlQuery? = nil,
-                 partitionId: PartitionId? = nil,
-                 query: Query? = nil,
-                 readOptions: ReadOptions? = nil) {
+    
+    public init(
+        gqlQuery: GqlQuery? = nil,
+        partitionId: PartitionId? = nil,
+        query: Query? = nil,
+        readOptions: ReadOptions? = nil
+    ) {
         self.gqlQuery = gqlQuery
         self.partitionId = partitionId
         self.query = query
         self.readOptions = readOptions
     }
+    
     /// The GQL query to run.
     public let gqlQuery: GqlQuery?
     /// Entities are partitioned into subsets, identified by a partition ID. Queries are scoped to a single partition. This partition ID is normalized with the standard default context partition ID.

--- a/Datastore/Sources/Data API/Models/Project API/Request/RunQueryRequest.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Request/RunQueryRequest.swift
@@ -6,12 +6,14 @@ public struct RunQueryRequest: GoogleCloudModel {
         gqlQuery: GqlQuery? = nil,
         partitionId: PartitionId? = nil,
         query: Query? = nil,
-        readOptions: ReadOptions? = nil
+        readOptions: ReadOptions? = nil,
+        databaseId: String? = nil
     ) {
         self.gqlQuery = gqlQuery
         self.partitionId = partitionId
         self.query = query
         self.readOptions = readOptions
+        self.databaseId = databaseId
     }
     
     /// The GQL query to run.
@@ -22,5 +24,8 @@ public struct RunQueryRequest: GoogleCloudModel {
     public let query: Query?
     /// The options for this query.
     public let readOptions: ReadOptions?
+    /// The ID of the database against which to make the request.
+    /// '(default)' is not allowed; please use empty string '' to refer the default database.
+    public let databaseId: String?
 }
 

--- a/Datastore/Sources/Data API/Models/Project API/Response/LookupResponse.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Response/LookupResponse.swift
@@ -1,7 +1,11 @@
 import Core
 
 public struct LookupResponse: GoogleCloudModel {
-    public init(deferred: [Key]? = nil, found: [EntityResult]? = nil, missing: [EntityResult]? = nil) {
+    public init(
+        deferred: [Key]? = nil,
+        found: [EntityResult]? = nil,
+        missing: [MissingEntityResult]? = nil
+    ) {
         self.deferred = deferred
         self.found = found
         self.missing = missing
@@ -11,5 +15,16 @@ public struct LookupResponse: GoogleCloudModel {
     /// Entities found as ResultType.FULL entities. The order of results in this field is undefined and has no relation to the order of the keys in the input.
     public let found: [EntityResult]?
     /// Entities not found as ResultType.KEY_ONLY entities. The order of results in this field is undefined and has no relation to the order of the keys in the input.
-    public let missing: [EntityResult]?
+    public let missing: [MissingEntityResult]?
+}
+
+public struct MissingEntityResult: GoogleCloudModel {
+    /// A KEY_ONLY entity
+    public let entity: MissingEntity
+    /// the version of the snapshot that was used to look up the entity
+    public let version: String
+    
+    public struct MissingEntity: GoogleCloudModel {
+        public let key: Key
+    }
 }

--- a/Datastore/Sources/Data API/Models/Project API/Response/RunAggregationQueryResponse.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Response/RunAggregationQueryResponse.swift
@@ -1,0 +1,20 @@
+import Core
+
+public struct RunAggregationQueryResponse: GoogleCloudModel {
+    /// A batch of query results (always present).
+    public let batch: AggregationResultBatch
+    /// The parsed form of the GqlQuery from the request, if it was set.
+    public let query: AggregationQuery?
+    public let transaction: String?
+}
+
+public struct AggregationResultBatch: Codable {
+    public let aggregationResults: [AggregationResult]
+}
+
+public struct AggregationResult: Codable {
+    public let aggregateProperties: AggregateProperties
+}
+
+public typealias AggregateProperties = [String: Value]
+

--- a/Datastore/Sources/Data API/Models/Project API/Response/RunQueryResponse.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Response/RunQueryResponse.swift
@@ -1,8 +1,10 @@
 import Core
 
 public struct RunQueryResponse: GoogleCloudModel {
-    public init(batch: QueryResultBatch? = nil,
-                 query: Query? = nil) {
+    public init(
+        batch: QueryResultBatch? = nil,
+        query: Query? = nil
+    ) {
         self.batch = batch
         self.query = query
     }

--- a/Datastore/Sources/Data API/Models/Project API/Types/AggregationQuery.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Types/AggregationQuery.swift
@@ -1,0 +1,62 @@
+public struct AggregationQuery: Codable {
+    
+    public let aggregations: [AggregationReference]
+    public let nestedQuery: Query
+    
+    init(
+        aggregations: [Aggregation],
+        nestedQuery: Query
+    ) {
+        self.aggregations = aggregations.map(AggregationReference.init)
+        self.nestedQuery = nestedQuery
+    }
+    
+    public struct AggregationReference: Codable {
+        
+        public let alias: String?
+        public let count: Count?
+        public let sum: Sum?
+        public let avg: Average?
+        
+        init(
+            alias: String? = nil,
+            count: Count? = nil,
+            sum: Sum? = nil,
+            avg: Average? = nil
+        ) {
+            self.alias = alias
+            self.count = count
+            self.sum = sum
+            self.avg = avg
+        }
+        
+        init(_ aggregration: Aggregation) {
+            switch aggregration {
+                case .count(alias: let alias, upTo: let upTo):
+                    self.init(alias: alias, count: Count(upTo: upTo)); return
+                case .sum(alias: let alias, property: let property):
+                    self.init(alias: alias, sum: Sum(property: property)); return
+                case .avg(alias: let alias, property: let property):
+                    self.init(alias: alias, avg: Average(property: property)); return
+            }
+        }
+        
+        public struct Count: Codable {
+            public let upTo: String?
+        }
+        
+        public struct Sum: Codable {
+            public let property: PropertyReference
+        }
+        
+        public struct Average: Codable {
+            public let property: PropertyReference
+        }
+    }
+}
+
+public enum Aggregation: Codable {
+    case count(alias: String? = nil, upTo: String? = nil)
+    case sum(alias: String? = nil, property: PropertyReference)
+    case avg(alias: String? = nil, property: PropertyReference)
+}

--- a/Datastore/Sources/Data API/Models/Project API/Types/Query.swift
+++ b/Datastore/Sources/Data API/Models/Project API/Types/Query.swift
@@ -82,22 +82,32 @@ public struct CompositeFilter: GoogleCloudModel {
     /// The list of filters to combine. Must contain at least one filter.
     public let filters: [Filter]
     /// The operator for combining multiple filters.
-    public let op: Operator?
+    public let op: Operator
     
     /// A composite filter operator.
     public enum Operator: String, RawRepresentable, GoogleCloudModel {
         /// The results are required to satisfy each of the combined filters.
         case and = "AND"
+        /// Documents are required to satisfy at least one of the combined filters.
+        case or = "OR"
     }
     
-    public init(_ filters: [Filter]) {
-        self.init(filters: filters, op: .and)
-    }
-    
-    init(filters: [Filter],
-         op: Operator? = nil) {
+    public init(
+        filters: [Filter],
+        op: Operator = .and
+    ) {
         self.filters = filters
         self.op = op
+    }
+    
+    public init(
+        filters: [Filter.TypedFilter],
+        op: Operator = .and
+    ) {
+        self.init(
+            filters: filters.map(Filter.init),
+            op: op
+        )
     }
 }
 


### PR DESCRIPTION
Adds support for aggregation queries (count, sum and average) against Datastores.

Also:
* Adds support for OR operator on composite datastore filters (previously only supported AND)
* Adds support for passing databaseId to datastore functions (previously only supported default database)
* Fixes LookupResponse model so missing entities can be correctly decoded (previously this would fail, as a missing entity does not have the same properties as one that exists)
