### PR TITLE
Exclude unhandled files from the related targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -67,35 +67,50 @@ let package = Package(
             dependencies: [
                 .target(name: "Core")
             ],
-            path: "Storage/Sources/"
+            path: "Storage/Sources/",
+            exclude: [
+                "README.md"
+            ]
         ),
         .target(
             name: "Datastore",
             dependencies: [
                 .target(name: "Core")
             ],
-            path: "Datastore/Sources/"
+            path: "Datastore/Sources/",
+            exclude: [
+                "README.md"
+            ]
         ),
         .target(
             name: "SecretManager",
             dependencies: [
                 .target(name: "Core")
             ],
-            path: "SecretManager/Sources"
+            path: "SecretManager/Sources",
+            exclude: [
+                "README.md"
+            ]
         ),
         .target(
             name: "IAMServiceAccountCredentials",
             dependencies: [
                 .target(name: "Core")
             ],
-            path: "IAMServiceAccountCredentials/Sources"
+            path: "IAMServiceAccountCredentials/Sources",
+            exclude: [
+                "README.md"
+            ]
         ),
         .target(
             name: "Translation",
             dependencies: [
                 .target(name: "Core")
             ],
-            path: "Translation/Sources"
+            path: "Translation/Sources",
+            exclude: [
+                "README.md"
+            ]
         ),
         .target(
             name: "PubSub",


### PR DESCRIPTION
Getting the following compiling warnings with Xcode 16 ⤵️

```
warning: 'google-cloud-kit': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    ~/google-cloud-kit/Storage/Sources/README.md
warning: 'google-cloud-kit': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    ~/google-cloud-kit/SecretManager/Sources/README.md
warning: 'google-cloud-kit': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    ~/google-cloud-kit/IAMServiceAccountCredentials/Sources/README.md
warning: 'google-cloud-kit': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    ~/google-cloud-kit/Datastore/Sources/README.md
```

This PR explicitly excludes unhandled files from the related targets 🫡