### PR TITLE
Fix Storage Object API Patch Method Failure

### DIFF
--- a/Storage/Sources/API/StorageObjectAPI.swift
+++ b/Storage/Sources/API/StorageObjectAPI.swift
@@ -440,7 +440,7 @@ public final class GoogleCloudStorageObjectAPI: StorageObjectAPI {
         
         do {
             let requestBody = try JSONSerialization.data(withJSONObject: ["metadata": metadata])
-            return request.send(method: .PATCH, path: "\(endpoint)/\(bucket)/o", query: queryParams, body: .data(requestBody))
+            return request.send(method: .PATCH, path: "\(endpoint)/\(bucket)/o/\(object.replacingOccurrences(of: "/", with: "%2F"))", query: queryParams, body: .data(requestBody))
         } catch {
             return request.eventLoop.makeFailedFuture(error)
         }

--- a/Storage/Sources/API/StorageObjectAPI.swift
+++ b/Storage/Sources/API/StorageObjectAPI.swift
@@ -439,7 +439,7 @@ public final class GoogleCloudStorageObjectAPI: StorageObjectAPI {
         }
         
         do {
-            let requestBody = try JSONSerialization.data(withJSONObject: metadata)
+            let requestBody = try JSONSerialization.data(withJSONObject: ["meatadata": metadata])
             return request.send(method: .PATCH, path: "\(endpoint)/\(bucket)/o", query: queryParams, body: .data(requestBody))
         } catch {
             return request.eventLoop.makeFailedFuture(error)

--- a/Storage/Sources/API/StorageObjectAPI.swift
+++ b/Storage/Sources/API/StorageObjectAPI.swift
@@ -439,7 +439,7 @@ public final class GoogleCloudStorageObjectAPI: StorageObjectAPI {
         }
         
         do {
-            let requestBody = try JSONSerialization.data(withJSONObject: ["meatadata": metadata])
+            let requestBody = try JSONSerialization.data(withJSONObject: ["metadata": metadata])
             return request.send(method: .PATCH, path: "\(endpoint)/\(bucket)/o", query: queryParams, body: .data(requestBody))
         } catch {
             return request.eventLoop.makeFailedFuture(error)


### PR DESCRIPTION
Modify JSON serialization to wrap metadata in a dictionary for Google Storage Object API patch method.